### PR TITLE
add BlockBufferSize method

### DIFF
--- a/container/writer.go
+++ b/container/writer.go
@@ -140,3 +140,9 @@ func (avroWriter *Writer) Flush() error {
 
 	return nil
 }
+
+// Get the current block buffer size.
+// caller might trigger an early Flush if current block size gets huge.
+func (avroWriter *Writer) BlockBufferSize() int {
+	return avroWriter.blockBuffer.Len()
+}


### PR DESCRIPTION
The size of each block is controlled by `recordsPerBlock`, which doesn't meet our needs.

In our use case, single written message might be huge, which results in java OOM error when parsing the resulting .avro file.

We propose to expose writer current block size by `BlockBufferSize` method, and let the caller decide to do an early block `Flush` to disk based on this exposed metric.